### PR TITLE
refactor(tls): use empty commonName to enforce SAN critical

### DIFF
--- a/internal/csi/backend/autotls.go
+++ b/internal/csi/backend/autotls.go
@@ -110,13 +110,17 @@ func (a *AutoTlsBackend) GetSecretData(ctx context.Context) (*util.SecretContent
 
 	notAfter := time.Now().Add(duration)
 
-	cnName := a.getCommonName()
+	// Set empty cnName, then san critical extension forced to be used
+	// From RFC 5280, Section 4.2.1.6
+	cnName := ""
 
+	logger.Info("Signe certificate", "commonName", cnName, "notAfter", notAfter, "addresses", addresses)
 	serverCert, err := certificateAuthority.SignServerCertificate(
 		cnName,
 		addresses,
 		notAfter,
 	)
+
 	if err != nil {
 		return nil, err
 	}
@@ -132,10 +136,6 @@ func (a *AutoTlsBackend) GetSecretData(ctx context.Context) (*util.SecretContent
 		Data:        data,
 		ExpiresTime: &expiresTime,
 	}, nil
-}
-
-func (a *AutoTlsBackend) getCommonName() string {
-	return a.podInfo.GetPodName()
 }
 
 func (a *AutoTlsBackend) getAddresses(ctx context.Context) ([]pod_info.Address, error) {

--- a/internal/csi/backend/ca/ca.go
+++ b/internal/csi/backend/ca/ca.go
@@ -155,7 +155,7 @@ func (c *CertificateAuthority) SignCertificate(template *x509.Certificate) (*Cer
 		return nil, err
 	}
 
-	logger.V(0).Info("Signed certificate", "commonName", template.Subject.CommonName, "notAfter", cert.NotAfter)
+	logger.V(0).Info("Signed certificate", "subject", cert.Subject, "notAfter", cert.NotAfter, "sanDns", cert.DNSNames, "sanIp", cert.IPAddresses)
 	return &Certificate{
 		Certificate: cert,
 		PrivateKey:  privateKey,


### PR DESCRIPTION
- https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6
- https://stackoverflow.com/a/5937270/11722440