### PR TITLE
feat(tls): enforce set san with critical

### DIFF
--- a/internal/csi/backend/autotls.go
+++ b/internal/csi/backend/autotls.go
@@ -200,11 +200,11 @@ func (a *AutoTlsBackend) GetSecretData(ctx context.Context) (*util.SecretContent
 		notAfter,
 	)
 
-	logger.Info("Signed certificate", "notAfter", notAfter, "addresses", addresses, "certLife", certLife, "certSerialNumber", cert.SerialNumber())
-
 	if err != nil {
 		return nil, err
 	}
+
+	logger.Info("Signed certificate", "notAfter", notAfter, "addresses", addresses, "certLife", certLife, "certSerialNumber", cert.SerialNumber())
 
 	data, err := a.certificateConvert(cert)
 	if err != nil {

--- a/test/e2e/tls/chainsaw-test.yaml
+++ b/test/e2e/tls/chainsaw-test.yaml
@@ -15,10 +15,14 @@ spec:
       catch:
       - sleep:
           duration: 5s
-      - podLogs:
-          selector: app.kubernetes.io/instance=secretcsi-csi
-          container: csi-secrets
-          tail: -1
+      - script:
+          env:
+            - name: NAMESPACE
+              value: ($namespace)
+          content: |
+            set -ex
+            kubectl -n $NAMESPACE get pods
+            kubectl -n 
       - describe:
           apiVersion: v1
           kind: Pod


### PR DESCRIPTION
From [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280), [Section 4.2.1.6](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6):

> If the subject field contains an empty sequence, then the issuer field MUST also contain an empty sequence and the subjectAltName extension MUST be marked as critical.

Golang x509 library automatically sets the critical flag if the subject field is empty.

https://github.com/golang/go/blob/9c93d99c616b8708bed55781915f7256051ab91e/src/crypto/x509/x509.go#L1187-L1199

But we expect pass a none-empty subject, so we set the san critical flag manually.