### PR TITLE
fix(ci): simplify chart-e2e with Makefile targets and fix --config

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -130,4 +130,4 @@ jobs:
 
           # E2E tests
           make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,50 +300,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v5
-
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.14.0
-        with:
-          cluster_name: kind
+      - name: Create kind cluster and install dependencies
+        run: make setup-chainsaw-cluster
 
-      - name: Load images to cluster
+      - name: Build, load images and install operator chart
         run: |
-          make docker-build
-          make csi-docker-build
-          kind load docker-image quay.io/zncdatadev/secret-operator:$VERSION quay.io/zncdatadev/secret-csi-driver:$VERSION
-
-      - name: Build helm chart
-        run: |
-          make helm-chart-package
-
-      - name: Install operator dependencies
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-            listener-operator
-          )
-
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
-
-      - name: Install operator chart
-        run: |
-          helm upgrade --install --create-namespace --namespace secret-operator --wait secret-operator \
+          make chainsaw docker-build csi-docker-build helm-chart-package
+          kind --name chainsaw-secret-operator load docker-image \
+            quay.io/zncdatadev/secret-operator:$VERSION \
+            quay.io/zncdatadev/secret-csi-driver:$VERSION
+          helm upgrade --install --create-namespace --namespace secret-operator \
+            --kubeconfig .kubeconfig --wait secret-operator \
             --set image.csiDriver.tag=$VERSION \
             ./target/charts/secret-operator-$VERSION.tgz
 
       - name: Run e2e tests
-        run: |
-          make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+        run: KUBECONFIG=.kubeconfig make chainsaw-e2e
 
 
   release-chart:


### PR DESCRIPTION
## Changes

1. **Simplify chart-e2e in release.yml** — replace inline shell scripts with Makefile targets:
   - `make setup-chainsaw-cluster` — create kind cluster + install operator dependencies (commons-operator, listener-operator)
   - `make docker-build csi-docker-build helm-chart-package` — build images and package chart
   - `make chainsaw-e2e` — run e2e tests (includes `--config`)

2. **Fix root cause: missing `--config` flag** — `chainsaw test --test-dir` without `--config` uses default 5s exec timeout. The tls-will-expires test polls for 90s, causing timeout failure. Now uses `--config ./test/e2e/.chainsaw.yaml` (45s exec timeout).

3. **Fix same `--config` issue in chart-lint-test.yml**

## Impact
- release.yml chart-e2e: 60 lines → 23 lines, aligned with test.yml pattern
- Fixes chart-e2e tls-will-expires test that was failing due to chainsaw default 5s exec timeout