### PR TITLE
fix(ci): create kind cluster before ct install

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -96,10 +96,18 @@ jobs:
           make docker-build
           make csi-docker-build
 
-      - name: Run chart-testing (install)
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.14.0
+
+      - name: Load images to cluster
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          ct install --config ./.github/configs/ct-install.yaml
+          kind load docker-image quay.io/zncdatadev/secret-operator:$VERSION quay.io/zncdatadev/secret-csi-driver:$VERSION
+
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --config ./.github/configs/ct-install.yaml
 
   chart-e2e:
     name: Chart E2E

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,15 @@ jobs:
           make docker-build
           make csi-docker-build
 
+      - name: Create kind cluster
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: helm/kind-action@v1.14.0
+
+      - name: Load images to cluster
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
+          kind load docker-image quay.io/zncdatadev/secret-operator:$VERSION quay.io/zncdatadev/secret-csi-driver:$VERSION
+
       - name: Run chart-testing (install)
         if: steps.check-changes.outputs.changed == 'true'
         run: |


### PR DESCRIPTION
ct install requires a running Kubernetes cluster. Both release.yml and chart-lint-test.yml were missing kind cluster setup before ct install, causing connection refused errors.