### PR TITLE
fix(ci): specify cluster name for kind load docker-image

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Load images to cluster
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          kind load docker-image quay.io/zncdatadev/secret-operator:$VERSION quay.io/zncdatadev/secret-csi-driver:$VERSION
+          kind load docker-image --name chart-testing quay.io/zncdatadev/secret-operator:$VERSION quay.io/zncdatadev/secret-csi-driver:$VERSION
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,7 +312,7 @@ jobs:
       - name: Load images to cluster
         if: steps.check-changes.outputs.changed == 'true'
         run: |
-          kind load docker-image quay.io/zncdatadev/secret-operator:$VERSION quay.io/zncdatadev/secret-csi-driver:$VERSION
+          kind load docker-image --name chart-testing quay.io/zncdatadev/secret-operator:$VERSION quay.io/zncdatadev/secret-csi-driver:$VERSION
 
       - name: Run chart-testing (install)
         if: steps.check-changes.outputs.changed == 'true'


### PR DESCRIPTION
## Problem

`helm/kind-action@v1.14.0` creates a kind cluster named `chart-testing`, but `kind load docker-image` defaults to cluster named `kind`, causing:

```
ERROR: no nodes found for cluster "kind"
```

## Why it only appeared in release pipeline

- **chart-lint-test.yml**: runs on PR/push to main. Most pushes don't change charts, so `if: steps.list-changed.outputs.changed == 'true'` skips the `kind load` step entirely — the bug was latent.
- **release.yml**: runs on tag push. The `0.4.0-dev` tag has chart changes, so `kind load` actually executes and hits the bug.

## Fix

Add `--name chart-testing` to `kind load docker-image` in both workflows.