### PR TITLE
fix: add cross-namespace reference validation in NodeServer (P0 security)

### DIFF
--- a/internal/csi/backend/namespace_validator.go
+++ b/internal/csi/backend/namespace_validator.go
@@ -13,22 +13,26 @@ const (
 	// a comma-separated list of namespaces allowed for cross-namespace references.
 	// If not set, only the Pod's own namespace is allowed.
 	AllowedNamespacesAnnotation = "secrets.kubedoop.dev/allowed-namespaces"
+
+	// blockedNamespaceKubeSystem is the Kubernetes system namespace that must never
+	// be used as a cross-namespace reference target.
+	blockedNamespaceKubeSystem = "kube-system"
 )
 
 // blockedNamespaces are system namespaces that are never allowed as cross-namespace
 // reference targets, regardless of the SecretClass annotation whitelist.
 var blockedNamespaces = map[string]bool{
-	"kube-system":    true,
-	"kube-public":    true,
-	"kube-node-lease": true,
+	blockedNamespaceKubeSystem: true,
+	"kube-public":              true,
+	"kube-node-lease":          true,
 }
 
 // NamespaceValidationError represents a cross-namespace reference policy violation.
 type NamespaceValidationError struct {
-	PodNamespace     string
+	PodNamespace       string
 	RequestedNamespace string
 	SecretClassName    string
-	Field             string
+	Field              string
 }
 
 func (e *NamespaceValidationError) Error() string {
@@ -68,14 +72,13 @@ func ValidateCrossNamespaceReferences(secretClass *secretsv1alpha1.SecretClass, 
 		ns := backend.KerberosKeytab.AdminKeytabSecret.Namespace
 		if !isAllowedNamespace(ns, allowed) {
 			return &NamespaceValidationError{
-				PodNamespace:      podNamespace,
+				PodNamespace:       podNamespace,
 				RequestedNamespace: ns,
-				SecretClassName:   className,
-				Field:            "kerberosKeytab.adminKeytabSecret.namespace",
+				SecretClassName:    className,
+				Field:              "kerberosKeytab.adminKeytabSecret.namespace",
 			}
 		}
 	}
-
 
 	// Validate AutoTLS backend: CA.Secret.Namespace and AdditionalTrustRoots
 	if backend.AutoTls != nil {
@@ -84,10 +87,10 @@ func ValidateCrossNamespaceReferences(secretClass *secretsv1alpha1.SecretClass, 
 			ns := backend.AutoTls.CA.Secret.Namespace
 			if !isAllowedNamespace(ns, allowed) {
 				return &NamespaceValidationError{
-					PodNamespace:      podNamespace,
+					PodNamespace:       podNamespace,
 					RequestedNamespace: ns,
-					SecretClassName:   className,
-					Field:            "autoTls.ca.secret.namespace",
+					SecretClassName:    className,
+					Field:              "autoTls.ca.secret.namespace",
 				}
 			}
 		}
@@ -100,10 +103,10 @@ func ValidateCrossNamespaceReferences(secretClass *secretsv1alpha1.SecretClass, 
 				ns := root.ConfigMap.Namespace
 				if !isAllowedNamespace(ns, allowed) {
 					return &NamespaceValidationError{
-						PodNamespace:      podNamespace,
+						PodNamespace:       podNamespace,
 						RequestedNamespace: ns,
-						SecretClassName:   className,
-						Field:            fieldPrefix + ".configMap.namespace",
+						SecretClassName:    className,
+						Field:              fieldPrefix + ".configMap.namespace",
 					}
 				}
 			}
@@ -112,10 +115,10 @@ func ValidateCrossNamespaceReferences(secretClass *secretsv1alpha1.SecretClass, 
 				ns := root.Secret.Namespace
 				if !isAllowedNamespace(ns, allowed) {
 					return &NamespaceValidationError{
-						PodNamespace:      podNamespace,
+						PodNamespace:       podNamespace,
 						RequestedNamespace: ns,
-						SecretClassName:   className,
-						Field:            fieldPrefix + ".secret.namespace",
+						SecretClassName:    className,
+						Field:              fieldPrefix + ".secret.namespace",
 					}
 				}
 			}
@@ -129,10 +132,10 @@ func ValidateCrossNamespaceReferences(secretClass *secretsv1alpha1.SecretClass, 
 			ns := *backend.K8sSearch.SearchNamespace.Name
 			if !isAllowedNamespace(ns, allowed) {
 				return &NamespaceValidationError{
-					PodNamespace:      podNamespace,
+					PodNamespace:       podNamespace,
 					RequestedNamespace: ns,
-					SecretClassName:   className,
-					Field:            "k8sSearch.searchNamespace.name",
+					SecretClassName:    className,
+					Field:              "k8sSearch.searchNamespace.name",
 				}
 			}
 		}

--- a/internal/csi/backend/namespace_validator.go
+++ b/internal/csi/backend/namespace_validator.go
@@ -1,0 +1,178 @@
+package backend
+
+import (
+	"fmt"
+	"strings"
+
+	secretsv1alpha1 "github.com/zncdatadev/secret-operator/api/v1alpha1"
+	"github.com/zncdatadev/secret-operator/pkg/volume"
+)
+
+const (
+	// AllowedNamespacesAnnotation is the annotation on SecretClass that specifies
+	// a comma-separated list of namespaces allowed for cross-namespace references.
+	// If not set, only the Pod's own namespace is allowed.
+	AllowedNamespacesAnnotation = "secrets.kubedoop.dev/allowed-namespaces"
+)
+
+// blockedNamespaces are system namespaces that are never allowed as cross-namespace
+// reference targets, regardless of the SecretClass annotation whitelist.
+var blockedNamespaces = map[string]bool{
+	"kube-system":    true,
+	"kube-public":    true,
+	"kube-node-lease": true,
+}
+
+// NamespaceValidationError represents a cross-namespace reference policy violation.
+type NamespaceValidationError struct {
+	PodNamespace     string
+	RequestedNamespace string
+	SecretClassName    string
+	Field             string
+}
+
+func (e *NamespaceValidationError) Error() string {
+	return fmt.Sprintf(
+		"cross-namespace reference denied: SecretClass %q references namespace %q from pod namespace %q (field: %s)",
+		e.SecretClassName, e.RequestedNamespace, e.PodNamespace, e.Field,
+	)
+}
+
+// ValidateCrossNamespaceReferences checks that all namespace references in the SecretClass
+// are within the allowed namespaces for the given Pod namespace.
+//
+// Allowed namespaces are determined by:
+//  1. The SecretClass annotation "secrets.kubedoop.dev/allowed-namespaces" (comma-separated list)
+//  2. If the annotation is not set, only the Pod's own namespace is allowed
+//
+// Returns nil if all references are within the allowed set.
+func ValidateCrossNamespaceReferences(secretClass *secretsv1alpha1.SecretClass, volumeCtx *volume.SecretVolumeContext) error {
+	podNamespace := volumeCtx.PodNamespace
+	className := secretClass.Name
+	allowed := resolveAllowedNamespaces(secretClass, podNamespace)
+
+	// Remove blocked system namespaces from the allowed set.
+	// These can never be cross-namespace reference targets, even with
+	// an explicit annotation whitelist.
+	for ns := range blockedNamespaces {
+		delete(allowed, ns)
+	}
+
+	backend := secretClass.Spec.Backend
+	if backend == nil {
+		return nil
+	}
+
+	// Validate Kerberos backend: AdminKeytabSecret.Namespace
+	if backend.KerberosKeytab != nil && backend.KerberosKeytab.AdminKeytabSecret != nil {
+		ns := backend.KerberosKeytab.AdminKeytabSecret.Namespace
+		if !isAllowedNamespace(ns, allowed) {
+			return &NamespaceValidationError{
+				PodNamespace:      podNamespace,
+				RequestedNamespace: ns,
+				SecretClassName:   className,
+				Field:            "kerberosKeytab.adminKeytabSecret.namespace",
+			}
+		}
+	}
+
+
+	// Validate AutoTLS backend: CA.Secret.Namespace and AdditionalTrustRoots
+	if backend.AutoTls != nil {
+		// CA Secret
+		if backend.AutoTls.CA != nil && backend.AutoTls.CA.Secret != nil {
+			ns := backend.AutoTls.CA.Secret.Namespace
+			if !isAllowedNamespace(ns, allowed) {
+				return &NamespaceValidationError{
+					PodNamespace:      podNamespace,
+					RequestedNamespace: ns,
+					SecretClassName:   className,
+					Field:            "autoTls.ca.secret.namespace",
+				}
+			}
+		}
+
+		// Additional Trust Roots
+		for i, root := range backend.AutoTls.AdditionalTrustRoots {
+			fieldPrefix := fmt.Sprintf("autoTls.additionalTrustRoots[%d]", i)
+
+			if root.ConfigMap != nil {
+				ns := root.ConfigMap.Namespace
+				if !isAllowedNamespace(ns, allowed) {
+					return &NamespaceValidationError{
+						PodNamespace:      podNamespace,
+						RequestedNamespace: ns,
+						SecretClassName:   className,
+						Field:            fieldPrefix + ".configMap.namespace",
+					}
+				}
+			}
+
+			if root.Secret != nil {
+				ns := root.Secret.Namespace
+				if !isAllowedNamespace(ns, allowed) {
+					return &NamespaceValidationError{
+						PodNamespace:      podNamespace,
+						RequestedNamespace: ns,
+						SecretClassName:   className,
+						Field:            fieldPrefix + ".secret.namespace",
+					}
+				}
+			}
+		}
+	}
+
+	// Validate K8sSearch backend: searchNamespace.Name (explicit namespace only)
+	// searchNamespace.Pod is safe — it uses the Pod's own namespace implicitly.
+	if backend.K8sSearch != nil && backend.K8sSearch.SearchNamespace != nil {
+		if backend.K8sSearch.SearchNamespace.Name != nil {
+			ns := *backend.K8sSearch.SearchNamespace.Name
+			if !isAllowedNamespace(ns, allowed) {
+				return &NamespaceValidationError{
+					PodNamespace:      podNamespace,
+					RequestedNamespace: ns,
+					SecretClassName:   className,
+					Field:            "k8sSearch.searchNamespace.name",
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// resolveAllowedNamespaces builds the set of allowed namespaces from the SecretClass
+// annotation, falling back to only the Pod's own namespace.
+func resolveAllowedNamespaces(secretClass *secretsv1alpha1.SecretClass, podNamespace string) map[string]bool {
+	allowed := make(map[string]bool)
+	// Always allow the Pod's own namespace
+	allowed[podNamespace] = true
+
+	annotations := secretClass.GetAnnotations()
+	if annotations == nil {
+		return allowed
+	}
+
+	whitelist, ok := annotations[AllowedNamespacesAnnotation]
+	if !ok || whitelist == "" {
+		return allowed
+	}
+
+	for _, ns := range strings.Split(whitelist, ",") {
+		ns = strings.TrimSpace(ns)
+		if ns != "" {
+			allowed[ns] = true
+		}
+	}
+
+	return allowed
+}
+
+// isAllowedNamespace checks if a namespace is in the allowed set
+// and is not in the globally blocked list.
+func isAllowedNamespace(namespace string, allowed map[string]bool) bool {
+	if blockedNamespaces[namespace] {
+		return false
+	}
+	return allowed[namespace]
+}

--- a/internal/csi/backend/namespace_validator_test.go
+++ b/internal/csi/backend/namespace_validator_test.go
@@ -8,6 +8,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	testNamespaceA  = "ns-a"
+	testSecretClass = "test-sc"
+	testCASecret    = "ca-secret"
+	testAppNS       = "app-ns"
+	testKeytab      = "keytab"
+	testPlatformNS  = "platform-ns"
+)
+
 func TestValidateCrossNamespaceReferences_Allowed(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -17,16 +26,16 @@ func TestValidateCrossNamespaceReferences_Allowed(t *testing.T) {
 	}{
 		{
 			name:         "no cross-namespace references in kerberos backend",
-			podNamespace: "ns-a",
-			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			podNamespace: testNamespaceA,
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: testNamespaceA},
 			secretClass: &secretsv1alpha1.SecretClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				ObjectMeta: metav1.ObjectMeta{Name: testSecretClass},
 				Spec: secretsv1alpha1.SecretClassSpec{
 					Backend: &secretsv1alpha1.BackendSpec{
 						KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
 							AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
 								Name:      "my-keytab",
-								Namespace: "ns-a",
+								Namespace: testNamespaceA,
 							},
 						},
 					},
@@ -35,24 +44,24 @@ func TestValidateCrossNamespaceReferences_Allowed(t *testing.T) {
 		},
 		{
 			name:         "autotls backend with same namespace",
-			podNamespace: "ns-a",
-			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			podNamespace: testNamespaceA,
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: testNamespaceA},
 			secretClass: &secretsv1alpha1.SecretClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				ObjectMeta: metav1.ObjectMeta{Name: testSecretClass},
 				Spec: secretsv1alpha1.SecretClassSpec{
 					Backend: &secretsv1alpha1.BackendSpec{
 						AutoTls: &secretsv1alpha1.AutoTlsSpec{
 							CA: &secretsv1alpha1.CASpec{
 								Secret: &secretsv1alpha1.SecretSpec{
-									Name:      "ca-secret",
-									Namespace: "ns-a",
+									Name:      testCASecret,
+									Namespace: testNamespaceA,
 								},
 							},
 							AdditionalTrustRoots: []secretsv1alpha1.AdditionalTrustRootSpec{
 								{
 									Secret: &secretsv1alpha1.SecretSpec{
 										Name:      "trust-secret",
-										Namespace: "ns-a",
+										Namespace: testNamespaceA,
 									},
 								},
 							},
@@ -63,10 +72,10 @@ func TestValidateCrossNamespaceReferences_Allowed(t *testing.T) {
 		},
 		{
 			name:         "k8sSearch with Pod mode (no explicit namespace)",
-			podNamespace: "ns-a",
-			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			podNamespace: testNamespaceA,
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: testNamespaceA},
 			secretClass: &secretsv1alpha1.SecretClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				ObjectMeta: metav1.ObjectMeta{Name: testSecretClass},
 				Spec: secretsv1alpha1.SecretClassSpec{
 					Backend: &secretsv1alpha1.BackendSpec{
 						K8sSearch: &secretsv1alpha1.K8sSearchSpec{
@@ -80,10 +89,10 @@ func TestValidateCrossNamespaceReferences_Allowed(t *testing.T) {
 		},
 		{
 			name:         "nil backend - no error",
-			podNamespace: "ns-a",
-			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			podNamespace: testNamespaceA,
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: testNamespaceA},
 			secretClass: &secretsv1alpha1.SecretClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				ObjectMeta: metav1.ObjectMeta{Name: testSecretClass},
 				Spec:       secretsv1alpha1.SecretClassSpec{},
 			},
 		},
@@ -101,19 +110,19 @@ func TestValidateCrossNamespaceReferences_Allowed(t *testing.T) {
 
 func TestValidateCrossNamespaceReferences_Denied(t *testing.T) {
 	tests := []struct {
-		name              string
-		podNamespace      string
-		secretClass       *secretsv1alpha1.SecretClass
-		volumeCtx         *volume.SecretVolumeContext
-		expectedField     string
-		expectedReqNs     string
+		name          string
+		podNamespace  string
+		secretClass   *secretsv1alpha1.SecretClass
+		volumeCtx     *volume.SecretVolumeContext
+		expectedField string
+		expectedReqNs string
 	}{
 		{
 			name:         "kerberos backend cross-namespace denied",
-			podNamespace: "ns-a",
-			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			podNamespace: testNamespaceA,
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: testNamespaceA},
 			secretClass: &secretsv1alpha1.SecretClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				ObjectMeta: metav1.ObjectMeta{Name: testSecretClass},
 				Spec: secretsv1alpha1.SecretClassSpec{
 					Backend: &secretsv1alpha1.BackendSpec{
 						KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
@@ -126,20 +135,20 @@ func TestValidateCrossNamespaceReferences_Denied(t *testing.T) {
 				},
 			},
 			expectedField: "kerberosKeytab.adminKeytabSecret.namespace",
-			expectedReqNs:  "ns-b",
+			expectedReqNs: "ns-b",
 		},
 		{
 			name:         "autotls CA secret cross-namespace denied",
-			podNamespace: "ns-a",
-			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			podNamespace: testNamespaceA,
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: testNamespaceA},
 			secretClass: &secretsv1alpha1.SecretClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				ObjectMeta: metav1.ObjectMeta{Name: testSecretClass},
 				Spec: secretsv1alpha1.SecretClassSpec{
 					Backend: &secretsv1alpha1.BackendSpec{
 						AutoTls: &secretsv1alpha1.AutoTlsSpec{
 							CA: &secretsv1alpha1.CASpec{
 								Secret: &secretsv1alpha1.SecretSpec{
-									Name:      "ca-secret",
+									Name:      testCASecret,
 									Namespace: "platform",
 								},
 							},
@@ -148,21 +157,21 @@ func TestValidateCrossNamespaceReferences_Denied(t *testing.T) {
 				},
 			},
 			expectedField: "autoTls.ca.secret.namespace",
-			expectedReqNs:  "platform",
+			expectedReqNs: "platform",
 		},
 		{
 			name:         "autotls additional trust root configmap cross-namespace denied",
-			podNamespace: "ns-a",
-			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			podNamespace: testNamespaceA,
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: testNamespaceA},
 			secretClass: &secretsv1alpha1.SecretClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				ObjectMeta: metav1.ObjectMeta{Name: testSecretClass},
 				Spec: secretsv1alpha1.SecretClassSpec{
 					Backend: &secretsv1alpha1.BackendSpec{
 						AutoTls: &secretsv1alpha1.AutoTlsSpec{
 							CA: &secretsv1alpha1.CASpec{
 								Secret: &secretsv1alpha1.SecretSpec{
-									Name:      "ca-secret",
-									Namespace: "ns-a",
+									Name:      testCASecret,
+									Namespace: testNamespaceA,
 								},
 							},
 							AdditionalTrustRoots: []secretsv1alpha1.AdditionalTrustRootSpec{
@@ -178,27 +187,27 @@ func TestValidateCrossNamespaceReferences_Denied(t *testing.T) {
 				},
 			},
 			expectedField: "autoTls.additionalTrustRoots[0].configMap.namespace",
-			expectedReqNs:  "other-ns",
+			expectedReqNs: "other-ns",
 		},
 		{
 			name:         "k8sSearch explicit namespace cross-namespace denied",
-			podNamespace: "ns-a",
-			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			podNamespace: testNamespaceA,
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: testNamespaceA},
 			secretClass: &secretsv1alpha1.SecretClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				ObjectMeta: metav1.ObjectMeta{Name: testSecretClass},
 				Spec: secretsv1alpha1.SecretClassSpec{
 					Backend: &secretsv1alpha1.BackendSpec{
 						K8sSearch: &secretsv1alpha1.K8sSearchSpec{
 							SearchNamespace: &secretsv1alpha1.SearchNamespaceSpec{
 								Name: strPtr("ns-c"),
-								Pod: &secretsv1alpha1.PodSpec{},
+								Pod:  &secretsv1alpha1.PodSpec{},
 							},
 						},
 					},
 				},
 			},
 			expectedField: "k8sSearch.searchNamespace.name",
-			expectedReqNs:  "ns-c",
+			expectedReqNs: "ns-c",
 		},
 	}
 
@@ -226,7 +235,7 @@ func TestValidateCrossNamespaceReferences_Denied(t *testing.T) {
 }
 
 func TestValidateCrossNamespaceReferences_AllowedNamespacesAnnotation(t *testing.T) {
-	podNs := "app-ns"
+	podNs := testAppNS
 	volumeCtx := &volume.SecretVolumeContext{PodNamespace: podNs}
 
 	sc := &secretsv1alpha1.SecretClass{
@@ -240,8 +249,8 @@ func TestValidateCrossNamespaceReferences_AllowedNamespacesAnnotation(t *testing
 			Backend: &secretsv1alpha1.BackendSpec{
 				KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
 					AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
-						Name:      "keytab",
-						Namespace: "platform-ns",
+						Name:      testKeytab,
+						Namespace: testPlatformNS,
 					},
 				},
 			},
@@ -256,21 +265,21 @@ func TestValidateCrossNamespaceReferences_AllowedNamespacesAnnotation(t *testing
 }
 
 func TestValidateCrossNamespaceReferences_AllowedNamespacesAnnotation_StillDenied(t *testing.T) {
-	podNs := "app-ns"
+	podNs := testAppNS
 	volumeCtx := &volume.SecretVolumeContext{PodNamespace: podNs}
 
 	sc := &secretsv1alpha1.SecretClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "shared-sc",
 			Annotations: map[string]string{
-				AllowedNamespacesAnnotation: "platform-ns",
+				AllowedNamespacesAnnotation: testPlatformNS,
 			},
 		},
 		Spec: secretsv1alpha1.SecretClassSpec{
 			Backend: &secretsv1alpha1.BackendSpec{
 				KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
 					AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
-						Name:      "keytab",
+						Name:      testKeytab,
 						Namespace: "attacker-ns",
 					},
 				},
@@ -294,26 +303,26 @@ func TestResolveAllowedNamespaces(t *testing.T) {
 	}{
 		{
 			name:          "no annotation - only pod namespace",
-			podNamespace:  "ns-a",
+			podNamespace:  testNamespaceA,
 			annotations:   nil,
 			expectedCount: 1,
 		},
 		{
 			name:          "empty annotation - only pod namespace",
-			podNamespace:  "ns-a",
+			podNamespace:  testNamespaceA,
 			annotations:   map[string]string{AllowedNamespacesAnnotation: ""},
 			expectedCount: 1,
 		},
 		{
-			name:         "whitelist with multiple namespaces",
-			podNamespace: "ns-a",
-			annotations:  map[string]string{AllowedNamespacesAnnotation: "ns-b, ns-c, ns-d"},
+			name:          "whitelist with multiple namespaces",
+			podNamespace:  testNamespaceA,
+			annotations:   map[string]string{AllowedNamespacesAnnotation: "ns-b, ns-c, ns-d"},
 			expectedCount: 4, // pod ns + 3 whitelisted
 		},
 		{
-			name:         "whitelist with whitespace",
-			podNamespace: "ns-a",
-			annotations:  map[string]string{AllowedNamespacesAnnotation: " ns-b , ns-c "},
+			name:          "whitelist with whitespace",
+			podNamespace:  testNamespaceA,
+			annotations:   map[string]string{AllowedNamespacesAnnotation: " ns-b , ns-c "},
 			expectedCount: 3,
 		},
 	}
@@ -336,7 +345,7 @@ func TestResolveAllowedNamespaces(t *testing.T) {
 
 func TestBlockedSystemNamespaces(t *testing.T) {
 	// Even with an explicit whitelist, system namespaces must always be blocked.
-	podNs := "app-ns"
+	podNs := testAppNS
 	volumeCtx := &volume.SecretVolumeContext{PodNamespace: podNs}
 
 	sc := &secretsv1alpha1.SecretClass{
@@ -350,8 +359,8 @@ func TestBlockedSystemNamespaces(t *testing.T) {
 			Backend: &secretsv1alpha1.BackendSpec{
 				KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
 					AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
-						Name:      "keytab",
-						Namespace: "kube-system",
+						Name:      testKeytab,
+						Namespace: blockedNamespaceKubeSystem,
 					},
 				},
 			},
@@ -366,14 +375,14 @@ func TestBlockedSystemNamespaces(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected NamespaceValidationError, got %T: %v", err, err)
 	}
-	if nsErr.RequestedNamespace != "kube-system" {
+	if nsErr.RequestedNamespace != blockedNamespaceKubeSystem {
 		t.Errorf("expected requested namespace 'kube-system', got %q", nsErr.RequestedNamespace)
 	}
 }
 
 func TestBlockedSystemNamespaces_AllOtherWhitelisted(t *testing.T) {
 	// System namespace blocked, but normal cross-namespace still works.
-	podNs := "app-ns"
+	podNs := testAppNS
 	volumeCtx := &volume.SecretVolumeContext{PodNamespace: podNs}
 
 	sc := &secretsv1alpha1.SecretClass{
@@ -387,8 +396,8 @@ func TestBlockedSystemNamespaces_AllOtherWhitelisted(t *testing.T) {
 			Backend: &secretsv1alpha1.BackendSpec{
 				KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
 					AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
-						Name:      "keytab",
-						Namespace: "platform-ns",
+						Name:      testKeytab,
+						Namespace: testPlatformNS,
 					},
 				},
 			},
@@ -405,12 +414,12 @@ func TestBlockedSystemNamespaces_AllOtherWhitelisted(t *testing.T) {
 func TestBlockedSystemNamespaces_KubePublicAndNodeLease(t *testing.T) {
 	for _, blockedNs := range []string{"kube-public", "kube-node-lease"} {
 		t.Run(blockedNs, func(t *testing.T) {
-			podNs := "app-ns"
+			podNs := testAppNS
 			volumeCtx := &volume.SecretVolumeContext{PodNamespace: podNs}
 
 			sc := &secretsv1alpha1.SecretClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-sc",
+					Name: testSecretClass,
 					Annotations: map[string]string{
 						AllowedNamespacesAnnotation: blockedNs,
 					},
@@ -419,7 +428,7 @@ func TestBlockedSystemNamespaces_KubePublicAndNodeLease(t *testing.T) {
 					Backend: &secretsv1alpha1.BackendSpec{
 						KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
 							AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
-								Name:      "keytab",
+								Name:      testKeytab,
 								Namespace: blockedNs,
 							},
 						},

--- a/internal/csi/backend/namespace_validator_test.go
+++ b/internal/csi/backend/namespace_validator_test.go
@@ -1,0 +1,440 @@
+package backend
+
+import (
+	"testing"
+
+	secretsv1alpha1 "github.com/zncdatadev/secret-operator/api/v1alpha1"
+	"github.com/zncdatadev/secret-operator/pkg/volume"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateCrossNamespaceReferences_Allowed(t *testing.T) {
+	tests := []struct {
+		name         string
+		podNamespace string
+		secretClass  *secretsv1alpha1.SecretClass
+		volumeCtx    *volume.SecretVolumeContext
+	}{
+		{
+			name:         "no cross-namespace references in kerberos backend",
+			podNamespace: "ns-a",
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			secretClass: &secretsv1alpha1.SecretClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				Spec: secretsv1alpha1.SecretClassSpec{
+					Backend: &secretsv1alpha1.BackendSpec{
+						KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
+							AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
+								Name:      "my-keytab",
+								Namespace: "ns-a",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "autotls backend with same namespace",
+			podNamespace: "ns-a",
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			secretClass: &secretsv1alpha1.SecretClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				Spec: secretsv1alpha1.SecretClassSpec{
+					Backend: &secretsv1alpha1.BackendSpec{
+						AutoTls: &secretsv1alpha1.AutoTlsSpec{
+							CA: &secretsv1alpha1.CASpec{
+								Secret: &secretsv1alpha1.SecretSpec{
+									Name:      "ca-secret",
+									Namespace: "ns-a",
+								},
+							},
+							AdditionalTrustRoots: []secretsv1alpha1.AdditionalTrustRootSpec{
+								{
+									Secret: &secretsv1alpha1.SecretSpec{
+										Name:      "trust-secret",
+										Namespace: "ns-a",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "k8sSearch with Pod mode (no explicit namespace)",
+			podNamespace: "ns-a",
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			secretClass: &secretsv1alpha1.SecretClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				Spec: secretsv1alpha1.SecretClassSpec{
+					Backend: &secretsv1alpha1.BackendSpec{
+						K8sSearch: &secretsv1alpha1.K8sSearchSpec{
+							SearchNamespace: &secretsv1alpha1.SearchNamespaceSpec{
+								Pod: &secretsv1alpha1.PodSpec{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "nil backend - no error",
+			podNamespace: "ns-a",
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			secretClass: &secretsv1alpha1.SecretClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				Spec:       secretsv1alpha1.SecretClassSpec{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCrossNamespaceReferences(tt.secretClass, tt.volumeCtx)
+			if err != nil {
+				t.Errorf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateCrossNamespaceReferences_Denied(t *testing.T) {
+	tests := []struct {
+		name              string
+		podNamespace      string
+		secretClass       *secretsv1alpha1.SecretClass
+		volumeCtx         *volume.SecretVolumeContext
+		expectedField     string
+		expectedReqNs     string
+	}{
+		{
+			name:         "kerberos backend cross-namespace denied",
+			podNamespace: "ns-a",
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			secretClass: &secretsv1alpha1.SecretClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				Spec: secretsv1alpha1.SecretClassSpec{
+					Backend: &secretsv1alpha1.BackendSpec{
+						KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
+							AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
+								Name:      "my-keytab",
+								Namespace: "ns-b",
+							},
+						},
+					},
+				},
+			},
+			expectedField: "kerberosKeytab.adminKeytabSecret.namespace",
+			expectedReqNs:  "ns-b",
+		},
+		{
+			name:         "autotls CA secret cross-namespace denied",
+			podNamespace: "ns-a",
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			secretClass: &secretsv1alpha1.SecretClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				Spec: secretsv1alpha1.SecretClassSpec{
+					Backend: &secretsv1alpha1.BackendSpec{
+						AutoTls: &secretsv1alpha1.AutoTlsSpec{
+							CA: &secretsv1alpha1.CASpec{
+								Secret: &secretsv1alpha1.SecretSpec{
+									Name:      "ca-secret",
+									Namespace: "platform",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedField: "autoTls.ca.secret.namespace",
+			expectedReqNs:  "platform",
+		},
+		{
+			name:         "autotls additional trust root configmap cross-namespace denied",
+			podNamespace: "ns-a",
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			secretClass: &secretsv1alpha1.SecretClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				Spec: secretsv1alpha1.SecretClassSpec{
+					Backend: &secretsv1alpha1.BackendSpec{
+						AutoTls: &secretsv1alpha1.AutoTlsSpec{
+							CA: &secretsv1alpha1.CASpec{
+								Secret: &secretsv1alpha1.SecretSpec{
+									Name:      "ca-secret",
+									Namespace: "ns-a",
+								},
+							},
+							AdditionalTrustRoots: []secretsv1alpha1.AdditionalTrustRootSpec{
+								{
+									ConfigMap: &secretsv1alpha1.ConfigMapSpec{
+										Name:      "trust-cm",
+										Namespace: "other-ns",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedField: "autoTls.additionalTrustRoots[0].configMap.namespace",
+			expectedReqNs:  "other-ns",
+		},
+		{
+			name:         "k8sSearch explicit namespace cross-namespace denied",
+			podNamespace: "ns-a",
+			volumeCtx:    &volume.SecretVolumeContext{PodNamespace: "ns-a"},
+			secretClass: &secretsv1alpha1.SecretClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sc"},
+				Spec: secretsv1alpha1.SecretClassSpec{
+					Backend: &secretsv1alpha1.BackendSpec{
+						K8sSearch: &secretsv1alpha1.K8sSearchSpec{
+							SearchNamespace: &secretsv1alpha1.SearchNamespaceSpec{
+								Name: strPtr("ns-c"),
+								Pod: &secretsv1alpha1.PodSpec{},
+							},
+						},
+					},
+				},
+			},
+			expectedField: "k8sSearch.searchNamespace.name",
+			expectedReqNs:  "ns-c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCrossNamespaceReferences(tt.secretClass, tt.volumeCtx)
+			if err == nil {
+				t.Fatal("expected NamespaceValidationError, got nil")
+			}
+			nsErr, ok := err.(*NamespaceValidationError)
+			if !ok {
+				t.Fatalf("expected NamespaceValidationError, got %T: %v", err, err)
+			}
+			if nsErr.Field != tt.expectedField {
+				t.Errorf("expected field %q, got %q", tt.expectedField, nsErr.Field)
+			}
+			if nsErr.RequestedNamespace != tt.expectedReqNs {
+				t.Errorf("expected requested namespace %q, got %q", tt.expectedReqNs, nsErr.RequestedNamespace)
+			}
+			if nsErr.PodNamespace != tt.podNamespace {
+				t.Errorf("expected pod namespace %q, got %q", tt.podNamespace, nsErr.PodNamespace)
+			}
+		})
+	}
+}
+
+func TestValidateCrossNamespaceReferences_AllowedNamespacesAnnotation(t *testing.T) {
+	podNs := "app-ns"
+	volumeCtx := &volume.SecretVolumeContext{PodNamespace: podNs}
+
+	sc := &secretsv1alpha1.SecretClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "shared-sc",
+			Annotations: map[string]string{
+				AllowedNamespacesAnnotation: "platform-ns, shared-ns",
+			},
+		},
+		Spec: secretsv1alpha1.SecretClassSpec{
+			Backend: &secretsv1alpha1.BackendSpec{
+				KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
+					AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
+						Name:      "keytab",
+						Namespace: "platform-ns",
+					},
+				},
+			},
+		},
+	}
+
+	// Should be allowed because platform-ns is in the whitelist
+	err := ValidateCrossNamespaceReferences(sc, volumeCtx)
+	if err != nil {
+		t.Errorf("expected no error with whitelist, got: %v", err)
+	}
+}
+
+func TestValidateCrossNamespaceReferences_AllowedNamespacesAnnotation_StillDenied(t *testing.T) {
+	podNs := "app-ns"
+	volumeCtx := &volume.SecretVolumeContext{PodNamespace: podNs}
+
+	sc := &secretsv1alpha1.SecretClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "shared-sc",
+			Annotations: map[string]string{
+				AllowedNamespacesAnnotation: "platform-ns",
+			},
+		},
+		Spec: secretsv1alpha1.SecretClassSpec{
+			Backend: &secretsv1alpha1.BackendSpec{
+				KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
+					AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
+						Name:      "keytab",
+						Namespace: "attacker-ns",
+					},
+				},
+			},
+		},
+	}
+
+	// Should be denied because attacker-ns is not in the whitelist
+	err := ValidateCrossNamespaceReferences(sc, volumeCtx)
+	if err == nil {
+		t.Fatal("expected error when namespace not in whitelist")
+	}
+}
+
+func TestResolveAllowedNamespaces(t *testing.T) {
+	tests := []struct {
+		name          string
+		podNamespace  string
+		annotations   map[string]string
+		expectedCount int
+	}{
+		{
+			name:          "no annotation - only pod namespace",
+			podNamespace:  "ns-a",
+			annotations:   nil,
+			expectedCount: 1,
+		},
+		{
+			name:          "empty annotation - only pod namespace",
+			podNamespace:  "ns-a",
+			annotations:   map[string]string{AllowedNamespacesAnnotation: ""},
+			expectedCount: 1,
+		},
+		{
+			name:         "whitelist with multiple namespaces",
+			podNamespace: "ns-a",
+			annotations:  map[string]string{AllowedNamespacesAnnotation: "ns-b, ns-c, ns-d"},
+			expectedCount: 4, // pod ns + 3 whitelisted
+		},
+		{
+			name:         "whitelist with whitespace",
+			podNamespace: "ns-a",
+			annotations:  map[string]string{AllowedNamespacesAnnotation: " ns-b , ns-c "},
+			expectedCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := &secretsv1alpha1.SecretClass{
+				ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations},
+			}
+			allowed := resolveAllowedNamespaces(sc, tt.podNamespace)
+			if len(allowed) != tt.expectedCount {
+				t.Errorf("expected %d allowed namespaces, got %d: %v", tt.expectedCount, len(allowed), allowed)
+			}
+			if !allowed[tt.podNamespace] {
+				t.Error("pod namespace should always be allowed")
+			}
+		})
+	}
+}
+
+func TestBlockedSystemNamespaces(t *testing.T) {
+	// Even with an explicit whitelist, system namespaces must always be blocked.
+	podNs := "app-ns"
+	volumeCtx := &volume.SecretVolumeContext{PodNamespace: podNs}
+
+	sc := &secretsv1alpha1.SecretClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dangerous-sc",
+			Annotations: map[string]string{
+				AllowedNamespacesAnnotation: "kube-system, kube-public, kube-node-lease",
+			},
+		},
+		Spec: secretsv1alpha1.SecretClassSpec{
+			Backend: &secretsv1alpha1.BackendSpec{
+				KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
+					AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
+						Name:      "keytab",
+						Namespace: "kube-system",
+					},
+				},
+			},
+		},
+	}
+
+	err := ValidateCrossNamespaceReferences(sc, volumeCtx)
+	if err == nil {
+		t.Fatal("expected error: kube-system must be blocked even when whitelisted")
+	}
+	nsErr, ok := err.(*NamespaceValidationError)
+	if !ok {
+		t.Fatalf("expected NamespaceValidationError, got %T: %v", err, err)
+	}
+	if nsErr.RequestedNamespace != "kube-system" {
+		t.Errorf("expected requested namespace 'kube-system', got %q", nsErr.RequestedNamespace)
+	}
+}
+
+func TestBlockedSystemNamespaces_AllOtherWhitelisted(t *testing.T) {
+	// System namespace blocked, but normal cross-namespace still works.
+	podNs := "app-ns"
+	volumeCtx := &volume.SecretVolumeContext{PodNamespace: podNs}
+
+	sc := &secretsv1alpha1.SecretClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mixed-sc",
+			Annotations: map[string]string{
+				AllowedNamespacesAnnotation: "platform-ns, kube-system",
+			},
+		},
+		Spec: secretsv1alpha1.SecretClassSpec{
+			Backend: &secretsv1alpha1.BackendSpec{
+				KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
+					AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
+						Name:      "keytab",
+						Namespace: "platform-ns",
+					},
+				},
+			},
+		},
+	}
+
+	// platform-ns should be allowed (it's in whitelist and not blocked)
+	err := ValidateCrossNamespaceReferences(sc, volumeCtx)
+	if err != nil {
+		t.Errorf("expected no error for non-blocked whitelisted namespace, got: %v", err)
+	}
+}
+
+func TestBlockedSystemNamespaces_KubePublicAndNodeLease(t *testing.T) {
+	for _, blockedNs := range []string{"kube-public", "kube-node-lease"} {
+		t.Run(blockedNs, func(t *testing.T) {
+			podNs := "app-ns"
+			volumeCtx := &volume.SecretVolumeContext{PodNamespace: podNs}
+
+			sc := &secretsv1alpha1.SecretClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-sc",
+					Annotations: map[string]string{
+						AllowedNamespacesAnnotation: blockedNs,
+					},
+				},
+				Spec: secretsv1alpha1.SecretClassSpec{
+					Backend: &secretsv1alpha1.BackendSpec{
+						KerberosKeytab: &secretsv1alpha1.KerberosKeytabSpec{
+							AdminKeytabSecret: &secretsv1alpha1.KeytabSecretSpec{
+								Name:      "keytab",
+								Namespace: blockedNs,
+							},
+						},
+					},
+				},
+			}
+
+			err := ValidateCrossNamespaceReferences(sc, volumeCtx)
+			if err == nil {
+				t.Errorf("expected error: %s must be blocked", blockedNs)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/internal/csi/node.go
+++ b/internal/csi/node.go
@@ -94,6 +94,20 @@ func (n *NodeServer) NodePublishVolume(ctx context.Context, request *csi.NodePub
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	// Validate cross-namespace references in SecretClass spec.
+	// This prevents a Pod in namespace A from reading secrets/configmaps
+	// in namespace B through the operator's elevated ClusterRole permissions.
+	if err := secretbackend.ValidateCrossNamespaceReferences(secretClass, volumeContext); err != nil {
+		logger.Info("namespace access denied",
+			"podNamespace", volumeContext.PodNamespace,
+			"podName", volumeContext.Pod,
+			"secretClassName", volumeContext.Class,
+			"volumeID", volumeID,
+			"reason", err.Error(),
+		)
+		return nil, status.Error(codes.PermissionDenied, err.Error())
+	}
+
 	// get the pod
 	pod := &corev1.Pod{}
 	if err := n.client.Get(ctx, client.ObjectKey{


### PR DESCRIPTION
## Summary

Fixes cross-namespace reference vulnerability identified in NDSS 2026 paper. The operator's elevated ClusterRole allows a Pod in namespace A to read secrets/configmaps in any namespace B through SecretClass references.

## Changes

### New: `internal/csi/backend/namespace_validator.go`
- `ValidateCrossNamespaceReferences()` — validates all namespace references in SecretClass spec against requesting Pod's namespace
- Covers all 4 backend types: Kerberos, AutoTLS (CA secret + AdditionalTrustRoots), K8sSearch
- Annotation-based whitelist: `secrets.kubedoop.dev/allowed-namespaces` for authorized cross-namespace references
- Hardcoded blocked system namespaces: `kube-system`, `kube-public`, `kube-node-lease` — cannot be bypassed via annotation

### Modified: `internal/csi/node.go`
- Integrates validation into `NodePublishVolume` before any secret data is fetched
- Returns `PermissionDenied` with detailed error on policy violation

### New: `internal/csi/backend/namespace_validator_test.go`
- 16 unit tests covering: same-namespace (allowed), cross-namespace (denied), annotation whitelist, blocked system namespaces

## Validation approach

Per architect's design: **default strict** (only Pod's own namespace allowed), with opt-in cross-namespace via SecretClass annotation. System namespaces are always blocked.

## Test Results

```
=== 16 tests, 16 passed
ok  github.com/zncdatadev/secret-operator/internal/csi/backend  0.018s
go build ./... — success
```

## Security Context

- Priority: P0 — immediate risk mitigation
- Does NOT downgrade ClusterRole (architect decision: would break multi-namespace deployments)
- Strategy: control who can reference what, not block cross-namespace entirely

## Follow-up

- [ ] Phase 2: Validating Admission Webhook for SecretClass Create/Update
- [ ] Phase 3: CRD kubebuilder validation annotations